### PR TITLE
Deprecating `body` and replacing with `response_body`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,5 @@ initial commit@ v 5...why not
 ## 1.2.5 (May 30, 2022)
 * add timeout
 * add insecure_skip_verify
+## 1.3.1 (Sep 05, 2022)
+* data-source/http: `body` is now deprecated and has been superseded by `response_body`. `body` will be removed in the next major release ([#11](https://github.com/salrashid123/terraform-provider-http-full/pull/11)).

--- a/docs/data-sources/http.md
+++ b/docs/data-sources/http.md
@@ -143,7 +143,9 @@ The following attributes are exported:
 
 * `status_code` - The status_code of the HTTP response if not error
 
-* `body` - The raw body of the HTTP response.
+* `body` (String, Deprecated) The raw body of the HTTP response. **NOTE**: This is deprecated, use `response_body` instead.
+
+* `response_body` (String) The raw body of the HTTP response.
 
 * `response_headers` - A map of strings representing the response HTTP headers.
   Duplicate headers are concatenated with `, ` according to

--- a/internal/provider/data_source.go
+++ b/internal/provider/data_source.go
@@ -79,8 +79,20 @@ func dataSource() *schema.Resource {
 			},
 
 			"body": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Description: "The raw body of the HTTP response. " +
+					"**NOTE**: This is deprecated, use `response_body` instead.",
+				Type:       schema.TypeString,
+				Computed:   true,
+				Deprecated: "Use response_body instead",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"response_body": {
+				Description: "The raw body of the HTTP response.",
+				Type:        schema.TypeString,
+				Computed:    true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
@@ -280,6 +292,10 @@ func dataSourceRead(ctx context.Context, d *schema.ResourceData, meta interface{
 
 	if err = d.Set("status_code", resp.StatusCode); err != nil {
 		return append(diags, diag.Errorf("Error setting HTTP status_code: %s", err)...)
+	}
+
+	if err = d.Set("response_body", string(bytes)); err != nil {
+		return append(diags, diag.Errorf("Error setting HTTP response body: %s", err)...)
 	}
 
 	if err = d.Set("response_headers", responseHeaders); err != nil {

--- a/internal/provider/data_source_test.go
+++ b/internal/provider/data_source_test.go
@@ -32,6 +32,10 @@ output "body" {
   value = data.http.http_test.body
 }
 
+output "response_body" {
+  value = data.http.http_test.response_body
+}
+
 output "response_headers" {
   value = data.http.http_test.response_headers
 }
@@ -59,6 +63,13 @@ func TestDataSource_http200(t *testing.T) {
 						return fmt.Errorf(
 							`'body' output is %s; want '1.0.0'`,
 							outputs["body"].Value,
+						)
+					}
+
+					if outputs["response_body"].Value != "1.0.0" {
+						return fmt.Errorf(
+							`'response_body' output is %s; want '1.0.0'`,
+							outputs["response_body"].Value,
 						)
 					}
 
@@ -129,8 +140,8 @@ data "http" "http_test" {
   url = "%s/errorwithbody"
 }
 
-output "body" {
-  value = data.http.http_test.body
+output "response_body" {
+  value = data.http.http_test.response_body
 }
 
 output "response_headers" {
@@ -163,8 +174,8 @@ data "http" "http_test" {
   }
 }
 
-output "body" {
-  value = data.http.http_test.body
+output "response_body" {
+  value = data.http.http_test.response_body
 }
 `
 
@@ -186,10 +197,10 @@ func TestDataSource_withHeaders200(t *testing.T) {
 
 					outputs := s.RootModule().Outputs
 
-					if outputs["body"].Value != "1.0.0" {
+					if outputs["response_body"].Value != "1.0.0" {
 						return fmt.Errorf(
-							`'body' output is %s; want '1.0.0'`,
-							outputs["body"].Value,
+							`'response_body' output is %s; want '1.0.0'`,
+							outputs["response_body"].Value,
 						)
 					}
 
@@ -209,8 +220,8 @@ output "status_code" {
 	value = data.http.http_test.status_code
 }
 
-output "body" {
-  value = "${data.http.http_test.body}"
+output "response_body" {
+  value = "${data.http.http_test.response_body}"
 }
 `
 
@@ -247,10 +258,10 @@ func TestDataSource_utf8(t *testing.T) {
 						)
 					}
 
-					if outputs["body"].Value != "1.0.0" {
+					if outputs["response_body"].Value != "1.0.0" {
 						return fmt.Errorf(
-							`'body' output is %s; want '1.0.0'`,
-							outputs["body"].Value,
+							`'response_body' output is %s; want '1.0.0'`,
+							outputs["response_body"].Value,
 						)
 					}
 
@@ -266,8 +277,8 @@ data "http" "http_test" {
   url = "%s/utf-16/meta_%d.txt"
 }
 
-output "body" {
-  value = "${data.http.http_test.body}"
+output "response_body" {
+  value = "${data.http.http_test.response_body}"
 }
 `
 
@@ -301,8 +312,8 @@ data "http" "http_test" {
   })  
 }
 
-output "body" {
-  value = "${data.http.http_test.body}"
+output "response_body" {
+  value = "${data.http.http_test.response_body}"
 }
 `
 
@@ -335,8 +346,8 @@ data "http" "http_test" {
   })  
 }
 
-output "body" {
-  value = "${data.http.http_test.body}"
+output "response_body" {
+  value = "${data.http.http_test.response_body}"
 }
 `
 
@@ -361,10 +372,10 @@ func TestDataSource_post(t *testing.T) {
 
 					outputs := s.RootModule().Outputs
 
-					if outputs["body"].Value != "1.0.0" {
+					if outputs["response_body"].Value != "1.0.0" {
 						return fmt.Errorf(
-							`'body' output is %s; want '1.0.0'`,
-							outputs["body"].Value,
+							`'response_body' output is %s; want '1.0.0'`,
+							outputs["response_body"].Value,
 						)
 					}
 
@@ -386,8 +397,8 @@ data "http" "http_test" {
   request_body = "foo=bar&bar=bar"
 }
 
-output "body" {
-  value = "${data.http.http_test.body}"
+output "response_body" {
+  value = "${data.http.http_test.response_body}"
 }
 `
 
@@ -412,10 +423,10 @@ func TestDataSource_form_post(t *testing.T) {
 
 					outputs := s.RootModule().Outputs
 
-					if outputs["body"].Value != "1.0.0" {
+					if outputs["response_body"].Value != "1.0.0" {
 						return fmt.Errorf(
-							`'body' output is %s; want '1.0.0'`,
-							outputs["body"].Value,
+							`'response_body' output is %s; want '1.0.0'`,
+							outputs["response_body"].Value,
 						)
 					}
 
@@ -545,8 +556,8 @@ data "http" "http_test" {
   client_key = "%s" 
 }
 
-output "body" {
-  value = "${data.http.http_test.body}"
+output "response_body" {
+  value = "${data.http.http_test.response_body}"
 }
 `
 
@@ -614,10 +625,10 @@ func TestDataSource_mtls(t *testing.T) {
 
 					outputs := s.RootModule().Outputs
 
-					if outputs["body"].Value != "1.0.0" {
+					if outputs["response_body"].Value != "1.0.0" {
 						return fmt.Errorf(
-							`'body' output is %s; want '1.0.0'`,
-							outputs["body"].Value,
+							`'response_body' output is %s; want '1.0.0'`,
+							outputs["response_body"].Value,
 						)
 					}
 
@@ -712,8 +723,8 @@ data "http" "http_test" {
   ca = "%s"
 }
 
-output "body" {
-  value = "${data.http.http_test.body}"
+output "response_body" {
+  value = "${data.http.http_test.response_body}"
 }
 `
 
@@ -738,8 +749,8 @@ data "http" "http_test" {
   insecure_skip_verify = true
 }
 
-output "body" {
-  value = "${data.http.http_test.body}"
+output "response_body" {
+  value = "${data.http.http_test.response_body}"
 }
 `
 
@@ -761,10 +772,10 @@ func TestDataSource_skip_tls_verify_success(t *testing.T) {
 
 					outputs := s.RootModule().Outputs
 
-					if outputs["body"].Value != "1.0.0" {
+					if outputs["response_body"].Value != "1.0.0" {
 						return fmt.Errorf(
-							`'body' output is %s; want '1.0.0'`,
-							outputs["body"].Value,
+							`'response_body' output is %s; want '1.0.0'`,
+							outputs["response_body"].Value,
 						)
 					}
 
@@ -782,8 +793,8 @@ data "http" "http_test" {
   sni = "foo"
 }
 
-output "body" {
-  value = "${data.http.http_test.body}"
+output "response_body" {
+  value = "${data.http.http_test.response_body}"
 }
 `
 
@@ -848,8 +859,8 @@ data "http" "http_test" {
   sni = "localhost"
 }
 
-output "body" {
-  value = "${data.http.http_test.body}"
+output "response_body" {
+  value = "${data.http.http_test.response_body}"
 }
 `
 
@@ -909,10 +920,10 @@ func TestDataSource_sni_success(t *testing.T) {
 
 					outputs := s.RootModule().Outputs
 
-					if outputs["body"].Value != "1.0.0" {
+					if outputs["response_body"].Value != "1.0.0" {
 						return fmt.Errorf(
-							`'body' output is %s; want '1.0.0'`,
-							outputs["body"].Value,
+							`'response_body' output is %s; want '1.0.0'`,
+							outputs["response_body"].Value,
 						)
 					}
 


### PR DESCRIPTION
Cherry picked from hashicorp/terraform-provider-http#137.

Fixes #10.